### PR TITLE
Fixed typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@
 This package provides functions to encode and decode secure cookie values.
 
 A secure cookie has its value ciphered and signed with a message authentication
-code. This prevents the remote cookie owner to know what information is stored 
-in the cookie and to modify it. It also prevent an attacker to forge a fake 
+code. This prevents the remote cookie owner from knowing what information is stored 
+in the cookie or modifying it. It also prevents an attacker from forging a fake 
 cookie.
 
-This package differ from the gorilla secure cookie in that its encoding and
+This package differs from the Gorilla secure cookie in that its encoding and
 decoding is 3 times faster and needs no heap allocation with an equivalent
 security strength. Both use AES128 and SHA256 to secure the value.
 
 **Note:** This package uses its own secure cookie value encoding. It is thus
-incompatible with Gorilla secure cookie package and the one provided with other
-langage frameworks. This encoding is simpler and more efficient, and adds a
-version number to support evolution with backward compatibility. 
+incompatible with the Gorilla secure cookie package and the ones provided with other
+language frameworks. This encoding is simpler and more efficient, and adds a
+version number to support evolution with backwards compatibility.
 
 **Warning:** Because this package impacts security of web applications,
-it is a critical functionaly. It still need reviews to be production ready.
+it is a critical functionality. It still needs reviews to be production ready.
 Feedback is welcome.
 
 ## Content
@@ -37,7 +37,7 @@ Feedback is welcome.
 
 ## Installation
 
-To intall or update this secure cookie package use the instruction:
+To install or update this secure cookie package use the instruction:
 
 ``` Bash
 go get -u "github.com/chmike/securecookie"
@@ -54,23 +54,25 @@ import "github.com/chmike/securecookie"
 ### Generating a random key
 
 It is strongly recommended to generate the random key with the following function.
-Save the key in a file using hex.EncodeToString() and restrict access to that file.
+Save the key in a file using `hex.EncodeToString()` and restrict access to that file.
 
 ``` Go
 var key []byte = securecookie.GenerateRandomKey()
 ```
 
-To mitigate the risk that an attacker get the saved key, you might store a second
+To mitigate the risk of an attacker getting the saved key, you might store a second
 key in another place and use the xor of both keys as secure cookie key. The attacker
-will have to get both keys to recontruct the effective key which should be more 
+will have to get both keys to reconstruct the effective key which should be more 
 difficult.
 
 ### Instantiating a cookie object
 
+To return an error if an argument is invalid, use `securecookie.New()`.
+
 ``` Go
 obj, err := securecookie.New("Auth", key, securecookie.Params{
-		Path:     "/sec",        // cookie is received only when URL start with this path
-		Domain:   "example.com", // cookie is received only when URL domain match this one
+		Path:     "/sec",        // cookie is received only when URL starts with this path
+		Domain:   "example.com", // cookie is received only when URL domain matches this one
 		MaxAge:   3600,          // cookie becomes invalid 3600 seconds after it is set
 		HTTPOnly: true,          // cookie is inaccessible to remote browser scripts 
 		Secure:   true,          // cookie is received only with HTTPS, never with HTTP
@@ -80,20 +82,21 @@ if err != nil {
 }
 ```
 
-It is also possible to instantiate a secure cookie object without returning
-an error and panic if an argument is invalid. In the following example,
-`Auth` is the cookie name and the Path is `/sec`. A secured value may be stored
-in the remote browse by calling the `SetValue()` method. After that, every 
-subsequent requests from that browser with a URL starting with `/sec` will have
-the cookie sent along. Calling the method `GetValue()` will extract the secure
-value from the request. A request to delete the cookie may be send to the 
-remote browser by calling the method `Delete()`.
+It is also possible to instantiate a secure cookie object without returning an
+error and panic if an argument is invalid. To do this, use
+`securecookie.MustNew()`. In the following example, `Auth` is the cookie name
+and the Path is `/sec`. A secured value may be stored in the remote browser by
+calling the `SetValue()` method. After that, every subsequent request from that
+browser with a URL starting with `/sec` will have the cookie sent along. Calling
+the method `GetValue()` will extract the secure value from the request. A
+request to delete the cookie may be sent to the remote browser by calling the
+method `Delete()`.
 
 ``` Go
 var obj = securecookie.MustNew("Auth", key, securecookie.Params{
-		Path:     "/sec",        // cookie is received only when URL start with this path
-		Domain:   "example.com", // cookie is received only when URL domain match this one
-		MaxAge:   3600,          // cookie becomes invalid 3600 seconds after it's set
+		Path:     "/sec",        // cookie is received only when URL starts with this path
+		Domain:   "example.com", // cookie is received only when URL domain matches this one
+		MaxAge:   3600,          // cookie becomes invalid 3600 seconds after it is set
 		HTTPOnly: true,          // cookie is inaccessible to remote browser scripts 
 		Secure:   true,          // cookie is received only with HTTPS, never with HTTP
 }
@@ -113,8 +116,8 @@ if err := obj.SetValue(w, val); err != nil {
 
 ### Decoding a secure cookie value
 
-The value is appended to the given buffer. If buf is nil a new buffer is
-allocated. If buf is too small it is grown. 
+The value is appended to the given buffer. If buf is `nil` a new buffer
+(`[]byte`) is allocated. If buf is too small it is grown.
 
 ``` Go
 // with r as the *http.Request
@@ -135,7 +138,7 @@ if err := obj.Delete(r); err != nil {
 }
 ```
 
-Note: don't rely on the assumption that the remote user agent (browser) will
+**Note:** don't rely on the assumption that the remote user agent (browser) will
 effectively delete the cookie. Evil users will try anything to break your site.
 
 ## Benchmarking
@@ -177,10 +180,10 @@ The differences between the Gorilla secure cookie and this implementation are:
 - This secure cookie encoding is incompatible with other secure cookie encoding.
   I don't know the status of Gorilla's encoding.
 - This encoding adds an encoding version number allowing to change or add new
-  encoding without breaking backward compatibility. Gorilla doesn't have this.
+  encoding without breaking backwards compatibility. Gorilla doesn't have this.
 - This package provides a Delete cookie method.
 
-This package and Gorilla provide both equivalently secure cookie if we discard
+This package and Gorilla both provide equivalently secure cookies if we discard
 the fact that no special measure is taken to conceal the key in memory and the
 value length. This package is quite new and needs more reviews to validate the
 security of the implementation.
@@ -189,7 +192,7 @@ Feedback and contributions are welcome.
 
 ## Value encoding
 
-1. A clear text mesage is first assembled as follow:
+1. A clear text message is first assembled as follow:
 
     [tag][nonce][stamp][value][padding]
 
@@ -197,16 +200,16 @@ Feedback and contributions are welcome.
     of the encoding (currently 0). The 2 less significant bits encode the number
     of padding bytes (0, 1 or 2). 3 is an invalid padding length. The number is
     picked so that the total length including the MAC is a multiple of 3. This
-    simplifies base64 encoding by avoiding it's padding.
-  - The nonce is 16 byte long (AES block length) and contains cryptographically
-    secure pseudo random bytes.
+    simplifies base64 encoding by avoiding its padding.
+  - The nonce is 16 bytes long (AES block length) and contains cryptographically
+    secure pseudorandom bytes.
   - The stamp is the unix time subtracted by an epochOffset value (1505230500),
     and encoded using the [LEB128 encoding](https://en.wikipedia.org/wiki/LEB128).
   - The value is a copy of the user provided value to secure.
-  - The padding bytes are cryptographically secure pseudo random bytes. There may
+  - The padding bytes are cryptographically secure pseudorandom bytes. There may
     be 0 to 2 padding bytes. The number is picked so that the total length
     including the MAC is a multiple of 3. This simplifies base64 encoding by
-    avoiding it's padding.
+    avoiding its padding.
 
 2. The stamp, value and padding bytes are ciphered using CTR-AES with the 16 last
    bytes of the key as ciphering key. The nonce is used as iv and counter
@@ -215,12 +218,12 @@ Feedback and contributions are welcome.
 3. An HMAC-SHA-256 is computed over (1) the cookie name and (2) the bytes sequence
    obtained after step 2. The 32 byte long MAC is appended after the padding.
 
-4. The whole byte sequence, form the tag to the last byte of the MAC is encoded in
+4. The whole byte sequence, from the tag to the last byte of the MAC is encoded in
    [Base64 using the URL encoding](https://tools.ietf.org/html/rfc4648#section-5).
    There is no padding since the byte length is a multiple of 3 bytes.
 
-The tag which provides an encoding version allows to completely change the encoding
-while preserving backward compatibilty if required.
+The tag which provides an encoding version allows completely changing the encoding
+while preserving backwards compatibility if required.
 
 ## Contributors
 
@@ -239,47 +242,47 @@ content. Nothing proves that the other data received by the server with a
 secure cookie has been created by the user's request.
 
 When you have properly set the domain path, and HTTPOnly with the
-Secure flag, and use HTTPS, only the user browser can send the cookie.
+Secure flag, and use HTTPS, only the user's browser can send the cookie.
 But it is still possible for an attacker to trick your browser to send
-a request to the site without the user knowledge and consent. This is known as
+a request to the site without the user's knowledge and consent. This is known as
 a [CSRF](https://en.wikipedia.org/wiki/Cross-site_request_forgery) attack.
 
-Consider this scenario with a Pizza ordering web site. First let see what
+Consider this scenario with a Pizza ordering web site. First let's see what
 happens when everything goes as expected.
 
-The user has to login the site to be allowed to order pizzas. During the
+The user has to login to the site to be allowed to order pizzas. During the
 login transaction a secure cookie is added into the user's browser. The user
 is then shown a form with the number of pizzas to order. When the user clicks
 the *Order* button, his browser will make a request to an URL provided with
 the form. It will join the field values and the secure cookie since the URL
 path and domain match the one specified at the login transaction.
 
-When the server receive this request, it checks the cookie validity to
+When the server receives this request, it checks the cookie validity to
 determine who that client is and if he is legitimate. All is fine. The order
 is then forwarded to the pizza chef. The pizza is later delivered to the
 user.
 
-Now comes the vilain. He set up some random site with a form and a validation
+Now comes the villain. He sets up some random site with a form and a validation
 button that the victim will very likely click (e.g., "Subscribe to spam" with
-a *Please no* button as validation button). The vilain has set up the form
+a *Please no* button as validation button). The villain has set up the form
 so that the URL associated to the validation button is the URL to order pizzas.
 He will have added a hidden field with the number of pizzas to order set to 10!
 
-When the user click that validation button, his browser will send a request
-to pizza ordering site with the field value and the secure cookie since the
-URL match the cookie path and domain.
+When the user clicks that validation button, his browser will send a request
+to the pizza ordering site with the field value and the secure cookie since the
+URL matches the cookie path and domain.
 
 The pizza ordering site checks the secure cookie and it will be authenticated.
-It will assume that the user issued that order. When the delevery man rings at
+It will assume that the user issued that order. When the delivery man rings at
 the user's door with 10 pizzas in his hand, there will be a conflict and no way
 to know to know who's fault it is. Notice how the value 10 associated with the
-cookie to the ordering request was not signed by the user's browser.
+cookie in the ordering request was not signed by the user's browser.
 
 To avoid this, the solution is to add a way to authenticate the form response.
 This is done by adding a hidden field in the form with a random byte sequence,
 and set a secure cookie with that byte sequence as value and a validity date
-limit. When the user fill that form, the server will receive back the secure
-cookie and the hidden field value. The server then check that they match to
+limit. When the user fills that form, the server will receive back the secure
+cookie and the hidden field value. The server then checks that they match to
 validate the response.
 
 An attacker can forge a random byte sequence, but can't forge the secure cookie
@@ -288,12 +291,12 @@ that goes with it.
 Note that this protection is void in case of XSS attack (script injection).
 
 The above method works with forms, not with REST API like requests because the
-server can't send the random token to the client that can use as challenge.
+server can't send the random token to the client that can be used as a challenge.
 For REST API like authenticated transactions, the client and server have to
 both know a secret byte sequence they use to compute a hmac value over the URI,
 the method, the data and a message sequence number. They can then authenticate
 the message and the source.
 
 The secret byte sequence can be determined in the authentication transaction
-with public and private keys. There is no need for TLS to securly authenticate
+with public and private keys. There is no need for TLS to securely authenticate
 the client and server. A secret cookie is no help here.

--- a/securecookie.go
+++ b/securecookie.go
@@ -2,21 +2,21 @@
 Package securecookie is a fast, efficient and safe cookie value encoder/decoder.
 
 A secure cookie has its value ciphered and signed with a message authentication
-code. This prevents the remote cookie owner to know what information is stored
-in the cookie and to modify it. It also prevent an attacker to forge a fake
+code. This prevents the remote cookie owner from knowing what information is stored
+in the cookie or modifying it. It also prevents an attacker from forging a fake
 cookie.
 
-The particularity of this secure cookie package is that it is fast (faster than
-the gorilla secure cookie), and value encoding and decoding needs zero heap
+What makes this secure cookie package different is that it is fast (faster than
+the Gorilla secure cookie), and value encoding and decoding needs zero heap
 allocations.
 
 The intended use is to instantiate at start up all secure cookie objects your
 web site may have to deal with. For instance:
 
 	obj, err := securecookie.New("Auth", key, securecookie.Params{
-		Path:     "/sec",        // cookie is received only when URL start with this path
-		Domain:   "example.com", // cookie is received only when URL domain match this one
-		MaxAge:   3600,          // cookie becomes invalid 3600 seconds after it's set
+		Path:     "/sec",        // cookie is received only when URL starts with this path
+		Domain:   "example.com", // cookie is received only when URL domain matches this one
+		MaxAge:   3600,          // cookie becomes invalid 3600 seconds after it is set
 		HTTPOnly: true,          // cookie is inaccessible to remote browser scripts
 		Secure:   true,          // cookie is received only with HTTPS, never with HTTP
 	})
@@ -24,7 +24,7 @@ web site may have to deal with. For instance:
 		// ...
 	}
 
-You may than set a secure cookie value in your handler with w being the
+You may then set a secure cookie value in your handler with w being the
 http.ResponseWriter. Note that obj is not modified by this call.
 
     var val = []byte("some value")
@@ -32,9 +32,9 @@ http.ResponseWriter. Note that obj is not modified by this call.
 		// ...
 	}
 
-You may than get the secure value with r being the *http.Request. Note
+You may then get the secure value with r being the *http.Request. Note
 that obj is not modified by this call. The value is appended to buf. If
-buf is nil, a new buffer is allocated. If it's too small, it is grown.
+buf is nil, a new buffer is allocated. If it is too small, it is grown.
 
     val, err := obj.GetValue(buf, r)
 	if err != nil {
@@ -68,7 +68,7 @@ import (
 // KeyLen is the byte length of the key.
 const KeyLen = 32
 
-// GenerateRandomKey return a random key of KeyLen bytes.
+// GenerateRandomKey returns a random key of KeyLen bytes.
 // Use hex.EncodeToString(key) to get the key as hexadecimal string,
 // and hex.DecodeString(keyStr) to convert back from string to byte slice.
 func GenerateRandomKey() ([]byte, error) {
@@ -79,17 +79,17 @@ func GenerateRandomKey() ([]byte, error) {
 	return key, nil
 }
 
-// An Params holds the cookie parameters. Use BytesToString() to convert
-// a []byte value to a string value without allocation and data copy, but
-// it requires that the value is not modified after the conversion.
-// To delete a cookie, set expire in the past and the path and domain
-// that are in the cookie to delete.
+// A Params value holds the cookie parameters. Use BytesToString() to convert a
+// []byte value to a string value without allocation and data copy, but it
+// requires that the value is not modified after the conversion. To delete a
+// cookie, set expire in the past and the path and domain that are in the cookie
+// to delete.
 type Params struct {
 	Path     string // Optional : URL path to which the cookie will be returned
 	Domain   string // Optional : domain to which the cookie will be returned
 	MaxAge   int    // Optional : time offset in seconds from now, must be > 0
 	HTTPOnly bool   // Optional : disallow access to the cookie by user agent scripts
-	Secure   bool   // Optional : cookie can only be send over HTTPS connections
+	Secure   bool   // Optional : cookie can only be sent over HTTPS connections
 }
 
 // Obj is a validated cookie object.
@@ -108,8 +108,8 @@ type Obj struct {
 	block    cipher.Block
 }
 
-// MustNew panic if New return a non-nil error, otherwise return a cookie
-// object. The intended use is to intialize global variables.
+// MustNew panics if New returns a non-nil error, otherwise returns a cookie
+// object. The intended use is to initialize global variables.
 func MustNew(name string, key []byte, p Params) *Obj {
 	o, err := New(name, key, p)
 	if err != nil {
@@ -118,7 +118,7 @@ func MustNew(name string, key []byte, p Params) *Obj {
 	return o
 }
 
-// New instantiate a validated cookie parameter field set with an associated key.
+// New instantiates a validated cookie parameter field set with an associated key.
 func New(name string, key []byte, p Params) (*Obj, error) {
 	block, err := aes.NewCipher(key[len(key)/2:])
 	if err != nil {
@@ -182,7 +182,7 @@ func New(name string, key []byte, p Params) (*Obj, error) {
 	return o, nil
 }
 
-// checkName return an error if the cookie name is invalid.
+// checkName returns an error if the cookie name is invalid.
 func checkName(name string) error {
 	if len(name) == 0 {
 		return errors.New("cookie name: empty value")
@@ -193,7 +193,7 @@ func checkName(name string) error {
 	return nil
 }
 
-// checkPath return an error if the cookie path is invalid
+// checkPath returns an error if the cookie path is invalid
 func checkPath(path string) error {
 	if err := checkChars(path, isValidPathChar); err != nil {
 		return fmt.Errorf("cookie path: %s", err)
@@ -201,7 +201,7 @@ func checkPath(path string) error {
 	return nil
 }
 
-// checkDomain return an error if the domain name is not valid.
+// checkDomain returns an error if the domain name is not valid.
 // See https://tools.ietf.org/html/rfc1034#section-3.5 and
 // https://tools.ietf.org/html/rfc1123#section-2.
 func checkDomain(name string) error {
@@ -212,7 +212,7 @@ func checkDomain(name string) error {
 		c := name[i]
 		if c == '.' {
 			if i == 0 {
-				return errors.New("cookie domain: start with '.'")
+				return errors.New("cookie domain: starts with '.'")
 			}
 			if pc := name[i-1]; pc == '-' || pc == '.' {
 				return fmt.Errorf("cookie domain: invalid character '%c' at offset %d", pc, i-1)
@@ -262,27 +262,27 @@ func checkChars(s string, isValid func(c byte) bool) error {
 	return nil
 }
 
-// Path return the cookie path field value.
+// Path returns the cookie path field value.
 func (o *Obj) Path() string {
 	return o.path
 }
 
-// Domain return the cookie domain field value.
+// Domain returns the cookie domain field value.
 func (o *Obj) Domain() string {
 	return o.domain
 }
 
-// MaxAge return the cookie max age field value.
+// MaxAge returns the cookie max age field value.
 func (o *Obj) MaxAge() int {
 	return o.maxAge
 }
 
-// HTTPOnly return the cookie HTTPOnly field value.
+// HTTPOnly returns the cookie HTTPOnly field value.
 func (o *Obj) HTTPOnly() bool {
 	return o.httpOnly
 }
 
-// Secure return the cookie HTTPOnly field value.
+// Secure returns the cookie HTTPOnly field value.
 func (o *Obj) Secure() bool {
 	return o.secure
 }
@@ -374,7 +374,7 @@ func encodeBase64(dst, src []byte) ([]byte, error) {
 	return dst, nil
 }
 
-// encodeUint64 encode v in b and return the bytes written.
+// encodeUint64 encodes v in b and returns the bytes written.
 // panic if b is not big enough. Max encoding length is 10.
 func encodeUint64(b []byte, v uint64) int {
 	var n int
@@ -414,7 +414,7 @@ func (o *Obj) GetValue(dst []byte, r *http.Request) ([]byte, error) {
 	return o.decodeValue(dst, c.Value)
 }
 
-// decodeValue append the encoded value val to dst.
+// decodeValue appends the encoded value val to dst.
 // dst is allocated if nil, or grown if too small.
 // Requires: len(val) >= minEncLen && len(val)%4 == 0.
 func (o *Obj) decodeValue(dst []byte, val string) ([]byte, error) {
@@ -472,8 +472,8 @@ func (o *Obj) decodeValue(dst []byte, val string) ([]byte, error) {
 	return append(dst, b[stampLen:len(b)-nPad]...), nil
 }
 
-// decodeBase64 append base64 encoded src to dst.
-// Return an error if len(src)%4 != 0 or src is not valid base64 encoding.
+// decodeBase64 appends base64 encoded src to dst.
+// Returns an error if len(src)%4 != 0 or src is not valid base64 encoding.
 // Requires cap(dst) - len(dst) >= (len(src)/4)*3.
 func decodeBase64(dst []byte, src string) ([]byte, error) {
 	if len(src)%4 != 0 {
@@ -516,7 +516,7 @@ func decodeBase64(dst []byte, src string) ([]byte, error) {
 	return dst, nil
 }
 
-// decodeUint64 encode v in b and return the number of
+// decodeUint64 encodes v in b and returns the number of
 // bytes read. If that value is 0, no value was read.
 func decodeUint64(b []byte) (uint64, int) {
 	var v uint64
@@ -534,7 +534,7 @@ func decodeUint64(b []byte) (uint64, int) {
 	return 0, 0
 }
 
-// Delete send a request to the remote user agent to delete the given
+// Delete sends a request to the remote user agent to delete the given
 // cookie. Note that the user agent may not execute the request.
 func (o *Obj) Delete(w http.ResponseWriter) error {
 	bPtr := bufPool.Get().(*[]byte)
@@ -571,7 +571,7 @@ func (o *Obj) hmacSha256(b []byte, data1 []byte) int {
 	return copy(b, digest[:])
 }
 
-// xorCtrAes computes the xor of data with encrypted ctr counter initialized bith iv.
+// xorCtrAes computes the xor of data with encrypted ctr counter initialized with iv.
 // It leaks timing information, but it is not a problem since the iv is public.
 func (o *Obj) xorCtrAes(iv []byte, data []byte) {
 	var buf = hmacBlockPool.Get().(*hmacBlock)
@@ -600,7 +600,7 @@ func (o *Obj) xorCtrAes(iv []byte, data []byte) {
 	}
 }
 
-// fillRandom fill b with cryptographically secure pseudorandom bytes.
+// fillRandom fills b with cryptographically secure pseudorandom bytes.
 func fillRandom(b []byte) error {
 	if forceError == 0 {
 		_, err := rand.Read(b)
@@ -616,8 +616,8 @@ func fillRandom(b []byte) error {
 // encodingVersion is the version of the generated encoding.
 const encodingVersion = 0
 
-// epochOffset is the number of seconds to subtract to the unix time to get
-// the epoch used in these secure cookie.
+// epochOffset is the number of seconds to subtract from the unix time to get
+// the epoch used in these secure cookies.
 const epochOffset uint64 = 1505230500
 
 // hmacLen is the byte length of the hmac(SHA256) digest.
@@ -644,7 +644,7 @@ type byteBlock [blockLen]byte
 // minEncLen is the minimum encoding length of a value.
 const minEncLen = ((1+ivLen+hmacLen)*8 + 5) / 6
 
-// maxCookieLen is the maximum len of a cookie.
+// maxCookieLen is the maximum length of a cookie.
 const maxCookieLen = 4000
 
 // forceError is used for 100% test coverage.

--- a/securecookie_test.go
+++ b/securecookie_test.go
@@ -175,7 +175,7 @@ func TestAccessorsMethods(t *testing.T) {
 		t.Errorf("got HTTP only %t, expected %t", obj.HTTPOnly(), params.HTTPOnly)
 	}
 	if obj.Secure() != params.Secure {
-		t.Errorf("got HTTP only %t, expected %t", obj.Secure(), params.Secure)
+		t.Errorf("got secure %t, expected %t", obj.Secure(), params.Secure)
 	}
 }
 


### PR DESCRIPTION
I saw that you did a lot of work on the documentation, so I just wanted to fix some typos I saw so they won't distract from what you are saying. There were a couple of things that were not really typos but I changed for consistency.