### PR TITLE
Correct time formatting for Expires field added by Obj.Delete() and add field for Max-Age=0

### DIFF
--- a/securecookie.go
+++ b/securecookie.go
@@ -703,7 +703,7 @@ func (o *Obj) Delete(w http.ResponseWriter) error {
 		b = append(b, "; Domain="...)
 		b = append(b, o.domain...)
 	}
-	b = append(b, "; Expires=Jan 2 15:04:05 2006"...)
+	b = append(b, "; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT"...)
 	if o.httpOnly {
 		b = append(b, "; HttpOnly"...)
 	}


### PR DESCRIPTION
Updates the time format used for the Expires field added by Obj.Delete() to align to [expected format for header dates per MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date). Also adds Max-Age=0 for good measure.